### PR TITLE
maryia/91511/fix: verify_email counter in withdrawal

### DIFF
--- a/packages/cashier/src/components/email-verification-empty-state/email-verification-empty-state.tsx
+++ b/packages/cashier/src/components/email-verification-empty-state/email-verification-empty-state.tsx
@@ -22,9 +22,9 @@ const EmailVerificationEmptyState = ({ verify }: TEmailVerificationEmptyStatePro
                 icon='IcEmailSent'
                 title={localize("We've sent you an email.")}
                 description={localize('Please check your email for the verification link to complete the process.')}
-                action={verify.has_been_sent ? undefined : action}
+                action={verify.sent_count > 1 ? undefined : action}
             />
-            {verify.has_been_sent && (
+            {verify.sent_count > 1 && (
                 <EmailVerificationResendEmptyState
                     is_counter_running={verify.is_counter_running}
                     counter={verify.counter}

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1185,7 +1185,7 @@ export default class ClientStore extends BaseStore {
 
     setSentVerifyEmailsData(sent_verify_emails_data) {
         this.sent_verify_emails_data = sent_verify_emails_data;
-        LocalStore.setObject('sent_verify_emails_data', sent_verify_emails_data);
+        sessionStorage.setItem('sent_verify_emails_data', JSON.stringify(sent_verify_emails_data));
     }
 
     setCookieAccount() {
@@ -1597,7 +1597,7 @@ export default class ClientStore extends BaseStore {
 
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
-        this.setSentVerifyEmailsData(LocalStore.getObject('sent_verify_emails_data'));
+        this.setSentVerifyEmailsData(JSON.parse(sessionStorage.getItem('sent_verify_emails_data')));
         this.setSwitched('');
         const client = this.accounts[this.loginid];
         // If there is an authorize_response, it means it was the first login

--- a/packages/hooks/src/useVerifyEmail.ts
+++ b/packages/hooks/src/useVerifyEmail.ts
@@ -11,7 +11,7 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     const WS = useWS('verify_email');
     const { client } = useStore();
     const { setSentVerifyEmailsData, sent_verify_emails_data } = client;
-    const { last_time_sent_seconds = 0, sent_count = 0 } = sent_verify_emails_data[type] || {};
+    const { last_time_sent_seconds = 0, sent_count = 0 } = sent_verify_emails_data?.[type] || {};
     const time_now_seconds = Math.floor(Date.now() / 1000);
     const seconds_left = last_time_sent_seconds + RESEND_COUNTDOWN - time_now_seconds;
     const should_not_allow_resend =
@@ -24,14 +24,19 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     }
 
     const send = () => {
-        if (!client.email) return;
-        if (counter.is_running) return;
+        if (!client.email || counter.is_running) return;
 
-        counter.reset();
-        counter.start();
+        if (sent_count > 0) {
+            counter.reset();
+            counter.start();
+        }
+
         const sent_emails_data = {
             ...sent_verify_emails_data,
-            [type]: { last_time_sent_seconds: time_now_seconds, sent_count: sent_count + 1 },
+            [type]: {
+                last_time_sent_seconds: sent_count && time_now_seconds,
+                sent_count: sent_count + 1,
+            },
         };
         setSentVerifyEmailsData(sent_emails_data);
 


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   to ensure Didn't Receive an email is shown before counter starts
-   to start verify_email counter in withdrawal only after second request
-   to store verify_email data in sessionStorage

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
